### PR TITLE
Update Planner with Markbook option

### DIFF
--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -323,6 +323,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                             $column->addCheckbox('homeworkCrowdAssessOtherParentsRead')->setValue('Y')->description(__('Other Parents'));
                 }
 
+                // MARKBOOK
+                $form->addRow()->addHeading(__('Markbook'));
+                // Check database for a linked markbook column
+                $data = array('gibbonPlannerEntryID' => $gibbonPlannerEntryID);
+                $sql = 'SELECT mb.gibbonMarkbookColumnID FROM gibbonMarkbookColumn AS mb WHERE :gibbonPlannerEntryID=mb.gibbonPlannerEntryID';
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+                if ($result->rowCount() != 0) {
+                    $row = $form->addRow();
+                    $row->addLabel('markbook', __('Markbook Column Already Created'))->description(__('A Markbook column has already been created for this assignment.'));
+                } else {
+                    $row = $form->addRow();
+                    $row->addLabel('markbook', __('Create Markbook Column?'))->description(__('Linked to this lesson by default.'));
+                    $row->addRadio('markbook')->fromArray(array('Y' => __('Yes'), 'N' => __('No')))->required()->checked('N')->inline(true);
+                }
+
                 // OUTCOMES
                 if ($viewBy == 'date') {
                     $form->addRow()->addHeading(__('Outcomes'));

--- a/modules/Planner/planner_editProcess.php
+++ b/modules/Planner/planner_editProcess.php
@@ -333,8 +333,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                             $URL .= "&return=warning1$params";
                             header("Location: {$URL}");
                         } else {
-                            $URL .= "&return=success0$params";
-                            header("Location: {$URL}");
+                            //Jump to Markbook?
+                            $markbook = $_POST['markbook'] ?? '';
+                            if ($markbook == 'Y') {
+                                $URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Markbook/markbook_edit_add.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&gibbonCourseClassID=$gibbonCourseClassID&gibbonUnitID=".$_POST['gibbonUnitID']."&date=$date&viewableParents=$viewableParents&viewableStudents=$viewableStudents&name=$name&summary=$summary&return=success1";
+                                header("Location: {$URL}");
+                                exit();
+                            } else {
+                                $URL .= "&return=success0&editID=".$gibbonPlannerEntryID.$params;
+                                header("Location: {$URL}");
+                                exit();
+                            }
                         }
                         //Notify participants
                         if (isset($_POST['notify'])) {


### PR DESCRIPTION
Updates the Planner module with the option to create and link a new Markbook Column when editing an already existing lesson plan.

<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Added lines to planner_edit and planner_editProcess that allows for the creation and linking of a Markbook Column when submitting a change to an already existing lesson plan.

**Motivation and Context**
This helps when planning lessons ahead of time, and a teacher doesn't know whether or not there will be homework. Now, a lesson can be planned ahead, and edited later with the opportunity to add a linked Markbook Column entry to the system.

**How Has This Been Tested?**
Tested and verified on a personal installation of Gibbon v22.

**Screenshots**
![EditLesson_1](https://user-images.githubusercontent.com/8291025/150211694-2da99777-177e-40f9-98a2-00f84f214be6.png)

